### PR TITLE
Display Data Tasks,Breaks and Study Data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13680,6 +13680,14 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-chartjs-2": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-3.0.3.tgz",
+      "integrity": "sha512-jOFZKwZ8sMLkddewZ/tToxuu4pYimAvvY5I6uK+hCpSFT16Pvo2bdHhUoZ0X87zu9I+dx2I+JCqaLN6XhmrbDg==",
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node-sass": "^6.0.0",
     "public-ip": "^4.0.4",
     "react": "^17.0.2",
+    "react-chartjs-2": "^3.0.3",
     "react-dom": "^17.0.2",
     "react-images-upload": "^1.2.8",
     "react-infinite-scroll-component": "^6.1.0",

--- a/src/components/Focus/Chart.js
+++ b/src/components/Focus/Chart.js
@@ -1,0 +1,181 @@
+import React from 'react';
+import './styles/Chart.scss';
+import { Line } from 'react-chartjs-2';
+import { convertMilli } from './helpers/convertMilli';
+
+function Chart({ label, data }) {
+	const sStart = data.start;
+	const sEnd = data.end;
+
+	const sStartDate = new Date(sStart.date.year, sStart.date.month, sStart.date.day, sStart.time.hours, sStart.time.minutes, sStart.time.seconds);
+	const sEndDate = new Date(sEnd.date.year, sEnd.date.month, sEnd.date.day, sEnd.time.hours, sEnd.time.minutes, sEnd.time.seconds);
+
+	const sStartTime = convertMilli(sStart.time.hours, 'hourM') + convertMilli(sStart.time.minutes, 'minM') + convertMilli(sStart.time.seconds, 'secM');
+	const sEndTime = convertMilli(sEnd.time.hours, 'hourM') + convertMilli(sEnd.time.minutes, 'minM') + convertMilli(sEnd.time.seconds, 'secM');
+
+	const timeDif = sEndTime - sStartTime;
+	const xlabels = [];
+	const ylabels = [];
+
+	const { taskList, doneTasks } = data.sessionInfo.tasks;
+	const totalTasks = taskList.concat(doneTasks);
+
+	if (timeDif >= 3600000) {
+		for (let i = sStartTime; i <= sEndTime; i = i + 600000) {
+			xlabels.push(`${('0' + convertMilli(i, 'hour')).slice(-2)}:${('0' + convertMilli(i, 'min')).slice(-2)}`);
+			ylabels.push(i + 1);
+		}
+	} else if (timeDif > 60000) {
+		for (let i = sStartTime; i <= sEndTime; i = i + 60000) {
+			xlabels.push(`${('0' + convertMilli(i, 'hour')).slice(-2)}:${('0' + convertMilli(i, 'min')).slice(-2)}`);
+			ylabels.push(i + 1);
+		}
+	} else {
+		for (let i = sStartTime; i <= sEndTime; i = i + 1000) {
+			xlabels.push(`${('0' + convertMilli(i, 'hour')).slice(-2)}:${('0' + convertMilli(i, 'min')).slice(-2)}:${('0' + convertMilli(i, 'sec')).slice(-2)}`);
+			ylabels.push(i + 1);
+		}
+	}
+
+	const createDataPoints = (dataArr, y) => {
+		let dataTimes = [];
+
+		for (let i = 0; i <= dataArr.length - 1; i++) {
+			let timeStart = dataArr[i].start;
+			let timeEnd = dataArr[i].end;
+			let secondsStart = timeDif < 60000 ? ':' + ('0' + timeStart.seconds).slice(-2) : '';
+			let secondsEnd = timeDif < 60000 ? ':' + ('0' + timeEnd.seconds).slice(-2) : '';
+
+			dataTimes.push(
+				{
+					x: `${('0' + timeStart.hours).slice(-2)}:${('0' + timeStart.minutes).slice(-2)}` + secondsStart,
+					y: y,
+					num: convertMilli(timeStart.hours, 'hourM') + convertMilli(timeStart.minutes, 'minM') + convertMilli(timeStart.seconds, 'secM'),
+				},
+				{
+					x: `${('0' + timeEnd.hours).slice(-2)}:${('0' + timeEnd.minutes).slice(-2)}` + secondsEnd,
+					y: y,
+					num: convertMilli(timeEnd.hours, 'hourM') + convertMilli(timeEnd.minutes, 'minM') + convertMilli(timeEnd.seconds, 'secM'),
+				},
+				{
+					x: NaN,
+					y: y,
+					num: 0,
+				}
+			);
+		}
+		return dataTimes;
+	};
+
+	let studyDataTimes = createDataPoints(data.sessionInfo.studyTimes, 1);
+
+	let sBreakTimes = createDataPoints(data.sessionInfo.shortBreakTimes, 2);
+
+	let lBreakTimes = createDataPoints(data.sessionInfo.longBreakTimes, 3);
+
+	const createTaskPoints = (taskType, val, y) => {
+		let tasks = [];
+
+		for (let i = 0; i <= taskType.length - 1; i++) {
+			let timeDis = taskType[i]['time' + val];
+			let taskDate = taskType[i]['date' + val];
+			let complDate = taskDate ? new Date(taskDate.year, taskDate.month, taskDate.day, timeDis.hours, timeDis.minutes, timeDis.seconds) : -1;
+
+			let seconds = timeDif < 60000 && timeDis ? ':' + ('0' + timeDis.seconds).slice(-2) : '';
+
+			if (complDate !== -1 && complDate > sStartDate && complDate < sEndDate) {
+				tasks.push({
+					x: timeDis && `${('0' + timeDis.hours).slice(-2)}:${('0' + timeDis.minutes).slice(-2)}` + seconds,
+					y: timeDis && y,
+					num: timeDis && convertMilli(timeDis.hours, 'hourM') + convertMilli(timeDis.minutes, 'minM') + convertMilli(timeDis.seconds, 'secM'),
+				});
+			}
+		}
+		return tasks;
+	};
+
+	let tasksStarted = createTaskPoints(totalTasks, '', 4);
+	let tasksFinished = createTaskPoints(totalTasks, 'Finished', 4);
+	let tasksReopened = createTaskPoints(totalTasks, 'Reopened', 4);
+
+	const state = {
+		labels: xlabels,
+		datasets: [
+			{
+				label: ' Study Data ',
+				backgroundColor: '#8eb798',
+				borderColor: '#498551',
+				data: studyDataTimes,
+			},
+			{
+				type: 'line',
+				label: ' Long Break ',
+				backgroundColor: '#84acc9',
+				borderColor: '#763ea8',
+				data: lBreakTimes,
+			},
+			{
+				label: ' Short Breaks ',
+				backgroundColor: 'rgba(75,192,192,1)',
+				borderColor: '#5599c5',
+				data: sBreakTimes,
+			},
+			{
+				type: 'scatter',
+				label: ' Task Reopened ',
+				backgroundColor: '#FFFF00',
+				borderColor: '#5599c5',
+				data: tasksReopened,
+			},
+			{
+				type: 'scatter',
+				label: ' Task Finished ',
+				backgroundColor: '#0000FF',
+				borderColor: '#5599c5',
+				data: tasksFinished,
+			},
+			{
+				type: 'scatter',
+				label: ' Tasks Started ',
+				backgroundColor: '#00FFFF',
+				borderColor: '#5599c5',
+				data: tasksStarted,
+			},
+		],
+	};
+
+	return (
+		<div className='chart-container'>
+			<Line
+				data={state}
+				options={{
+					plugins: {
+						title: {
+							display: true,
+							text: 'Study Data',
+						},
+					},
+					scales: {
+						x: {
+							title: {
+								display: true,
+								text: 'Time',
+							},
+						},
+						y: {
+							title: {
+								display: true,
+								text: 'Type',
+							},
+							ticks: {
+								stepSize: 1,
+							},
+						},
+					},
+				}}
+			/>
+		</div>
+	);
+}
+
+export default Chart;

--- a/src/components/Focus/DataDropdown.js
+++ b/src/components/Focus/DataDropdown.js
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import Chart from './Chart';
+import './styles/DataDropdown.scss';
+import { Typography } from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
+
+function DataDropdown({ session_times }) {
+	const [checked, setChecked] = useState(new Array(session_times.length).fill(false));
+	const [numChecked, setNumChecked] = useState(0);
+
+	const getDate = (sessionDate, sessionStartTime, sessionEndTime) => {
+		let date = new Date(sessionDate.year, sessionDate.month, sessionDate.day, sessionStartTime.hours, sessionStartTime.minutes, sessionStartTime.seconds);
+		return `${date.toDateString()}`;
+	};
+
+	useEffect(() => {
+		let tempArr = checked.filter((check) => {
+			return check === true;
+		})
+		setNumChecked(tempArr.length);
+	}, [checked])
+
+	const handleToggleAll = () => {
+		if (numChecked === session_times.length) {
+			setChecked(new Array(checked.length).fill(false));
+		} else {
+			setChecked(new Array(checked.length).fill(true));
+		}
+	};
+
+	const handleChange = (value) => {
+		let tempArr = checked.map((check,id) =>
+							value === id? !check:check
+						);
+		setChecked(tempArr)
+	};
+
+	const present = () => {
+		console.log(checked);
+		console.log(numChecked);
+	};
+
+	return (
+		<div className='data-dropdown-container'>
+			<button onClick={present}>present</button>
+			<CardHeader
+				avatar={
+					<Checkbox
+						onClick={handleToggleAll}
+						checked={numChecked === session_times.length}
+						disabled={session_times && session_times.length === 0}
+						inputProps={{ 'aria-label': 'all items selected' }}
+					/>
+				}
+				title='Saved Sessions Selected'
+				subheader={`${numChecked}/${session_times.length} selected`}
+			/>
+			<Divider />
+			{session_times.map((session, id) => {
+				return (
+					<Accordion key={id}>
+						<AccordionSummary expandIcon={<ExpandMoreIcon />} aria-label='Expand' aria-controls='additional-actions1-content' id='additional-actions1-header'>
+							<FormControlLabel
+								aria-label='Acknowledge'
+								onClick={(event) => {
+									event.stopPropagation();
+								}}
+								onFocus={(event) => event.stopPropagation()}
+								control={<Checkbox checked={checked[id] && checked[id]} onClick={()=>handleChange(id)} type='checkbox' label={id} value={id} />}
+								label={getDate(session.start.date, session.start.time, session.end.time)}
+							/>
+							<Typography className='secondary-heading'>
+								{`${('0' + session.start.time.hours).slice(-2)}:${('0' + session.start.time.minutes).slice(-2)}:${('0' + session.start.time.seconds).slice(-2)} - ${(
+									'0' + session.end.time.hours
+								).slice(-2)}:
+								${('0' + session.end.time.minutes).slice(-2)}:${('0' + session.end.time.seconds).slice(-2)}`}
+							</Typography>
+						</AccordionSummary>
+						<AccordionDetails>
+							<Chart label='Study Data' data={session} />
+						</AccordionDetails>
+					</Accordion>
+				);
+			})}
+		</div>
+	);
+}
+
+export default DataDropdown;

--- a/src/components/Focus/DataPopup.js
+++ b/src/components/Focus/DataPopup.js
@@ -6,88 +6,73 @@ import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import { Grid, Box, Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
-function DataPopup({ session, open, handleClose }) {
+function DataPopup({ session, open, handleClose, setInSession, inSession, ready }) {
+	const history = useHistory();
+
 	const studies = useSelector((state) => state.studyData.studies);
 	const study_times = useSelector((state) => state.studyData.study_times);
-	const short_breaks = useSelector(
-		(state) => state.studyData.short_breaks_taken
-	);
+	const short_breaks = useSelector((state) => state.studyData.short_breaks_taken);
 	const long_breaks = useSelector((state) => state.studyData.long_breaks_taken);
 
+	const [toData, setToData] = React.useState(false);
+
+	const toDataPage = () => {
+		if (inSession === 1) {
+			if (ready) {
+				setInSession(2);
+			} else {
+				setInSession(3);
+			}
+		}
+		if (ready || inSession === 0) {
+			setToData(!toData);
+		}
+	};
+
+	React.useEffect(() => {
+		if (toData) {
+			history.push('/data');
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [toData]);
+
 	return (
-		<Dialog
-			onClose={handleClose}
-			aria-labelledby='customized-dialog-title'
-			open={open}
-			className='data-popup'
-			fullScreen
-			fullWidth
-		>
+		<Dialog onClose={handleClose} aria-labelledby='customized-dialog-title' open={open} className='data-popup' fullScreen fullWidth>
 			<Box className='container'>
 				<Grid container justify='space-between' alignItems='baseline'>
 					<Typography variant='h4' gutterBottom>
 						Your Data
 					</Typography>
-					<IconButton
-						aria-label='close'
-						onClick={handleClose}
-						className='close-btn'
-					>
+					<IconButton aria-label='close' onClick={handleClose} className='close-btn'>
 						<CloseIcon />
 					</IconButton>
 				</Grid>
 				<div>
+					<Typography gutterBottom>Number of Pomodoro Sessions: {studies}</Typography>
+					<Typography gutterBottom>Number of Short Breaks: {short_breaks}</Typography>
+					<Typography gutterBottom>Number of Long Breaks: {long_breaks} </Typography>
 					<Typography gutterBottom>
-						Number of Pomodoro Sessions: {studies}
-					</Typography>
-					<Typography gutterBottom>
-						Number of Short Breaks: {short_breaks}
-					</Typography>
-					<Typography gutterBottom>
-						Number of Long Breaks: {long_breaks}{' '}
-					</Typography>
-					<Typography gutterBottom>
-						Current Study Session Time:{' '}
-						<span>
-							{(
-								'0' + Math.floor((session.currentTime / (1000 * 60 * 60)) % 24)
-							).slice(-2)}
-						</span>
-						:
-						<span>
-							{('0' + Math.floor((session.currentTime / 60000) % 60)).slice(-2)}
-						</span>
-						:
-						<span>
-							{('0' + Math.floor((session.currentTime / 1000) % 60)).slice(-2)}
-						</span>
+						Current Study Session Time: <span>{('0' + Math.floor((session.currentTime / (1000 * 60 * 60)) % 24)).slice(-2)}</span>:
+						<span>{('0' + Math.floor((session.currentTime / 60000) % 60)).slice(-2)}</span>:<span>{('0' + Math.floor((session.currentTime / 1000) % 60)).slice(-2)}</span>
 					</Typography>
 					<Typography variant='h6' gutterBottom>
 						Your Pomodoro Sessions:
 						<ul>
 							{study_times.map((time, id) => (
 								<li key={id}>
-									start: {('0' + time.start.hours).slice(-2)}:
-									{('0' + time.start.minutes).slice(-2)}:
-									{('0' + time.start.seconds).slice(-2)}, end:{' '}
-									{('0' + time.end.hours).slice(-2)}:
-									{('0' + time.end.minutes).slice(-2)}:
-									{('0' + time.end.seconds).slice(-2)} study time:{' '}
-									{('0' + time.timeSpent.hour).slice(-2)}:
-									{('0' + time.timeSpent.min).slice(-2)}:
+									start: {('0' + time.start.hours).slice(-2)}:{('0' + time.start.minutes).slice(-2)}:{('0' + time.start.seconds).slice(-2)}, end: {('0' + time.end.hours).slice(-2)}:
+									{('0' + time.end.minutes).slice(-2)}:{('0' + time.end.seconds).slice(-2)} study time: {('0' + time.timeSpent.hour).slice(-2)}:{('0' + time.timeSpent.min).slice(-2)}:
 									{('0' + time.timeSpent.sec).slice(-2)}
 								</li>
 							))}
 						</ul>
 					</Typography>
 				</div>
-				<Link to={'/data'}>
-					<Button autoFocus onClick={handleClose} color='primary'>
-						Data Page
-					</Button>
-				</Link>
+				<Button onClick={toDataPage} color='primary'>
+					{ready || inSession === 0 ? <>Data Page</> : <>End Session to go to Data Page</>}
+				</Button>
 			</Box>
 		</Dialog>
 	);

--- a/src/components/Focus/PinnedTask.js
+++ b/src/components/Focus/PinnedTask.js
@@ -1,20 +1,29 @@
-import React, { useState } from 'react';
+import React from 'react';
 import './styles/PinnedTask.scss';
 import { Paper, Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import { faStar } from '@fortawesome/free-solid-svg-icons';
+import { faThumbtack } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 function PinnedTask({ paperCol }) {
 	const pinTask = useSelector((state) => state.task.favoriteTask);
 
 	return (
-		<Paper elevation={1} className='pinned-container' style={paperCol}>
-			<Typography variant='h6'>
-				<FontAwesomeIcon icon={faStar} className='pinned-icon' />
-				{pinTask}
-			</Typography>
-		</Paper>
+		<Accordion className='pinned-container' style={paperCol}>
+			<AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls='panel1a-content' id='panel1a-header'>
+				<FontAwesomeIcon icon={faThumbtack} className='pinned-icon' />
+				<Typography variant='h6'>Pinned Task </Typography>
+			</AccordionSummary>
+			<AccordionDetails>
+				<Typography variant='h6' className='pinned-task'>
+					{pinTask}
+				</Typography>
+			</AccordionDetails>
+		</Accordion>
 	);
 }
 

--- a/src/components/Focus/TaskList.js
+++ b/src/components/Focus/TaskList.js
@@ -5,7 +5,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import { IconButton, Checkbox } from '@material-ui/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrashAlt, faStar } from '@fortawesome/free-solid-svg-icons';
+import { faTrashAlt, faThumbtack } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
 
 function TaskList({ handleCheckChange, favoredTask, deleteTask }) {
@@ -17,39 +17,21 @@ function TaskList({ handleCheckChange, favoredTask, deleteTask }) {
 			{rxTaskList.map((task, id) => (
 				<ListItem key={id} role={undefined} dense button>
 					<ListItemIcon>
-						<Checkbox
-							edge='start'
-							onChange={handleCheckChange}
-							name={task.task}
-							color='primary'
-							checked={false}
-						/>
+						<Checkbox edge='start' onChange={handleCheckChange} name={task.task} color='primary' checked={false} />
 					</ListItemIcon>
 					<ListItemText id={id} primary={task.task} />
-					<IconButton
-						color='secondary'
-						component='span'
-						className='add-des'
-						style={{ color: '#FF0000' }}
-						onClick={() => deleteTask(0, task)}
-						edge='end'
-						aria-label='delete'
-					>
+					<IconButton color='secondary' component='span' className='add-des' style={{ color: '#FF0000' }} onClick={() => deleteTask(0, task)} edge='end' aria-label='delete'>
 						<FontAwesomeIcon icon={faTrashAlt} />
 					</IconButton>
 					<IconButton
 						component='span'
 						className='add-des'
-						style={
-							rxFavTask === task.task
-								? { color: '#FFD700' }
-								: { color: '#7E7E7E' }
-						}
+						style={rxFavTask === task.task ? { color: '#FFD700' } : { color: '#7E7E7E' }}
 						onClick={() => favoredTask(task.task)}
 						edge='end'
 						aria-label='pin'
 					>
-						<FontAwesomeIcon icon={faStar} />
+						<FontAwesomeIcon icon={faThumbtack} />
 					</IconButton>
 				</ListItem>
 			))}

--- a/src/components/Focus/TaskPopup.js
+++ b/src/components/Focus/TaskPopup.js
@@ -2,14 +2,7 @@ import React, { useState } from 'react';
 import './styles/TaskPopup.scss';
 import Dialog from '@material-ui/core/Dialog';
 import CloseIcon from '@material-ui/icons/Close';
-import {
-	Grid,
-	Button,
-	Typography,
-	IconButton,
-	Checkbox,
-	Switch,
-} from '@material-ui/core';
+import { Grid, Button, Typography, IconButton, Switch } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
 import { TaskActionCreators } from '../../redux/actions/task';
@@ -54,10 +47,16 @@ function TaskPopup({ session, open, handleClose }) {
 				minutes: d.getMinutes(),
 				seconds: d.getSeconds(),
 			};
+			let date = {
+				day: d.getDate(),
+				month: d.getMonth() + 1,
+				year: d.getFullYear(),
+			};
 			dispatch(
 				TaskActionCreators.addTask({
 					task: input,
 					time: time,
+					date: date,
 					finished: false,
 				})
 			);
@@ -75,6 +74,11 @@ function TaskPopup({ session, open, handleClose }) {
 			minutes: d.getMinutes(),
 			seconds: d.getSeconds(),
 		};
+		let date = {
+			day: d.getDate(),
+			month: d.getMonth() + 1,
+			year: d.getFullYear(),
+		};
 		rxTaskList.forEach((task) => {
 			if (task.task === e.target.name) {
 				if (e.target.name === rxFavTask) {
@@ -83,6 +87,7 @@ function TaskPopup({ session, open, handleClose }) {
 				dispatch(TaskActionCreators.deleteDoneTask(task));
 				task['timeFinished'] = time;
 				task['finished'] = true;
+				task['dateFinished'] = date;
 				dispatch(TaskActionCreators.addDoneTask(task));
 				dispatch(TaskActionCreators.deleteTask(task));
 			}
@@ -96,10 +101,16 @@ function TaskPopup({ session, open, handleClose }) {
 			minutes: d.getMinutes(),
 			seconds: d.getSeconds(),
 		};
+		let date = {
+			day: d.getDate(),
+			month: d.getMonth() + 1,
+			year: d.getFullYear(),
+		};
 		rxDoneTasks.forEach((task) => {
 			if (task.task === e.target.name) {
 				dispatch(TaskActionCreators.deleteTask(task));
 				task['timeReopened'] = time;
+				task['dateReopened'] = date;
 				task['finished'] = false;
 				dispatch(TaskActionCreators.addTask(task));
 				dispatch(TaskActionCreators.deleteDoneTask(task));
@@ -138,23 +149,12 @@ function TaskPopup({ session, open, handleClose }) {
 	};
 
 	return (
-		<Dialog
-			onClose={handleCloseData}
-			aria-labelledby='customized-dialog-title'
-			open={open}
-			className='task-popup'
-			fullScreen
-			fullWidth
-		>
+		<Dialog onClose={handleCloseData} aria-labelledby='customized-dialog-title' open={open} className='task-popup' fullScreen fullWidth>
 			<Grid container className='container'>
 				{!showDoneTask ? (
 					<Grid item container direction='column'>
 						<Grid item>
-							<Typography
-								variant='h4'
-								gutterBottom
-								style={{ height: 'fit-content' }}
-							>
+							<Typography variant='h4' gutterBottom style={{ height: 'fit-content' }}>
 								Your Tasks
 								<Switch
 									checked={showDoneTask}
@@ -165,11 +165,7 @@ function TaskPopup({ session, open, handleClose }) {
 									disabled={!(rxDoneTasks.length > 0)}
 								/>
 							</Typography>
-							<IconButton
-								className='close-btn'
-								aria-label='close'
-								onClick={handleCloseData}
-							>
+							<IconButton className='close-btn' aria-label='close' onClick={handleCloseData}>
 								<CloseIcon />
 							</IconButton>
 						</Grid>
@@ -183,46 +179,23 @@ function TaskPopup({ session, open, handleClose }) {
 									}}
 								/>
 							) : (
-								<Typography
-									variant='subtitle1'
-									gutterBottom
-									className='marginMd'
-								>
+								<Typography variant='subtitle1' gutterBottom className='marginMd'>
 									Create some tasks and they'll show up here
 								</Typography>
 							)}
 						</Grid>
 						<Grid item className='form-grid'>
-							<form
-								noValidate
-								autoComplete='off'
-								className='task-input'
-								onSubmit={handleSubmit}
-							>
+							<form noValidate autoComplete='off' className='task-input' onSubmit={handleSubmit}>
 								<Grid container justify='center' alignItems='center'>
 									<Grid item xs={11}>
-										<Snackbar
-											open={openWarning}
-											autoHideDuration={5000}
-											onClose={handleWarningClose}
-										>
+										<Snackbar open={openWarning} autoHideDuration={5000} onClose={handleWarningClose}>
 											<Alert onClose={handleWarningClose} severity='warning'>
 												You already have that task!
 											</Alert>
 										</Snackbar>
-										<TextField
-											required
-											fullWidth
-											value={input}
-											label='Add a task'
-											onChange={(e) => setInput(e.target.value)}
-										/>
+										<TextField required fullWidth value={input} label='Add a task' onChange={(e) => setInput(e.target.value)} />
 									</Grid>
-									<Button
-										type='submit'
-										disabled={!input}
-										className='submit-form'
-									>
+									<Button type='submit' disabled={!input} className='submit-form'>
 										<FontAwesomeIcon icon={faPen} />
 									</Button>
 								</Grid>
@@ -234,18 +207,9 @@ function TaskPopup({ session, open, handleClose }) {
 						<Grid item>
 							<Typography variant='h4' gutterBottom>
 								Your Finished Tasks
-								<Switch
-									checked={showDoneTask}
-									onChange={handleSwitchChange}
-									name='showTask'
-									inputProps={{ 'aria-label': 'checkbox with default color' }}
-								/>
+								<Switch checked={showDoneTask} onChange={handleSwitchChange} name='showTask' inputProps={{ 'aria-label': 'checkbox with default color' }} />
 							</Typography>
-							<IconButton
-								className='close-btn'
-								aria-label='close'
-								onClick={handleCloseData}
-							>
+							<IconButton className='close-btn' aria-label='close' onClick={handleCloseData}>
 								<CloseIcon />
 							</IconButton>
 						</Grid>

--- a/src/components/Focus/styles/Chart.scss
+++ b/src/components/Focus/styles/Chart.scss
@@ -1,0 +1,3 @@
+.chart-container {
+	width: 50%;
+}

--- a/src/components/Focus/styles/DataDropdown.scss
+++ b/src/components/Focus/styles/DataDropdown.scss
@@ -1,0 +1,6 @@
+.data-dropdown-container {
+	.secondary-heading {
+		color: #a9a9a9;
+		margin: 9px;
+	}
+}

--- a/src/components/Focus/styles/PinnedTask.scss
+++ b/src/components/Focus/styles/PinnedTask.scss
@@ -1,10 +1,16 @@
 .pinned-container {
-	padding: 20px;
 	background-color: #498551;
 	color: #fff !important;
+	border-radius: 20px !important;
+	box-shadow: 0px 3px 3px -2px rgba(0, 0, 0, 0.2), 0px 3px 4px 0px rgba(0, 0, 0, 0.14), 0px 1px 8px 0px rgba(0, 0, 0, 0.12) !important;
 
 	.pinned-icon {
 		color: #ffd700;
-		margin: 0 10px 0 0;
+		margin: 10px 5px;
+		font-size: 1.5rem;
+	}
+
+	.pinned-task {
+		overflow: hidden;
 	}
 }

--- a/src/components/Focus/styles/TaskPopup.scss
+++ b/src/components/Focus/styles/TaskPopup.scss
@@ -44,7 +44,7 @@
 	}
 
 	.add-des {
-		font-size: 1.2rem;
+		font-size: 1.5rem;
 		color: #9fadf6;
 		margin: 5px;
 	}

--- a/src/components/generic/Navbar.js
+++ b/src/components/generic/Navbar.js
@@ -1,6 +1,6 @@
 import './styles/navbar.scss';
 import Nav from './Nav';
-import { useSelector } from 'react-redux';
+// import { useSelector } from 'react-redux';
 
 function NavBar(props) {
 	// const email = useSelector((state) => state.user.profile.email);

--- a/src/pages/Datapage.js
+++ b/src/pages/Datapage.js
@@ -1,34 +1,33 @@
-import React, { useState } from 'react';
+import React from 'react';
 import './styles/DataPage.scss';
-import { Grid, Typography, Button } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import { useDispatch } from 'react-redux';
-import { TimerActionCreators } from '../redux/actions/timer';
-import { StudyActionCreators } from '../redux/actions/studyData';
-import { TaskActionCreators } from '../redux/actions/task';
+import DataDropdown from '../components/Focus/DataDropdown';
 
 function Datapage() {
-	const dispatch = useDispatch();
+	// Study Data
+	const session_times = useSelector((state) => state.studyData.session_times);
 
-	const deepStudy = useSelector((state) => state.timer.deep_study);
+	// Timer Data
+	const timerData = {
+		taskList: useSelector((state) => state.task.taskList),
+		doneTasks: useSelector((state) => state.task.doneTasks),
+	};
 
-	const clearAll = () => {
-		dispatch(TimerActionCreators.clearState());
-		dispatch(StudyActionCreators.clearState());
-		dispatch(TaskActionCreators.clearState());
+	const presentAll = () => {
+		console.log(session_times);
+		console.log(timerData);
 	};
 
 	return (
-		<Grid
-			container
-			justify='center'
-			alignItems='flex-start'
-			className='data-container'
-		>
+		<Grid container justify='center' alignItems='flex-start' className='data-container'>
 			<Grid item xs={12}>
 				<Typography variant='h1'>Data</Typography>
 			</Grid>
-			<button onClick={clearAll}>Clear</button>
+			<Grid item xs={12}>
+				<DataDropdown session_times={session_times} />
+			</Grid>
+			<button onClick={presentAll}>Present</button>
 		</Grid>
 	);
 }

--- a/src/pages/Focus.js
+++ b/src/pages/Focus.js
@@ -17,10 +17,14 @@ function Focus({ handleLogout }) {
 
 	const [background, setBackground] = useState({ background: '' });
 	const [paperCol, setPaperCol] = useState({ backgroundColor: '#498551' });
-	const [inSession, setInSession] = useState(0);
+	const [ready, setReady] = useState(false); //ready to end session
+
+	const [inSession, setInSession] = useState(0); //0: not in session, 1: in session, 2: session just ended,  3: user wants session to end
 	const changeBackground = (color, paperColor) => {
 		setPaperCol(paperColor);
-		setBackground({ background: `linear-gradient( ${color[0]} 0% ,${color[1]} 74%)` });
+		setBackground({
+			background: `linear-gradient( ${color[0]} 0% ,${color[1]} 74%)`,
+		});
 	};
 	const clearAll = () => {
 		dispatch(TimerActionCreators.clearState());
@@ -29,39 +33,30 @@ function Focus({ handleLogout }) {
 	};
 
 	return (
-		<Grid
-			container
-			justify='center'
-			alignItems='flex-start'
-			className='page-container'
-			style={background}
-		>
+		<Grid container justify='center' alignItems='flex-start' className='page-container' style={background}>
 			<Grid item xs={10}>
 				<Typography variant='h2'>Timer</Typography>
 			</Grid>
 			<Grid item xs={2}>
-				{deepStudy && inSession === 1 && (
-					<Button onClick={() => setInSession(2)} className='timer-buttons'>
+				{deepStudy && (inSession === 1 || inSession === 3) && (
+					<Button
+						onClick={() => {
+							if (ready) {
+								setInSession(2);
+							} else {
+								setInSession(3);
+							}
+						}}
+						className='end-session'
+					>
 						End Session
 					</Button>
 				)}
 			</Grid>
 
-			<Grid
-				item
-				xs={12}
-				container
-				justify='center'
-				alignItems='center'
-				direction='column'
-				sapcing={3}
-			>
+			<Grid item xs={12} container justify='center' alignItems='center' direction='column' sapcing={3}>
 				<Grid item xs={6}>
-					<Timer
-						changeBackground={changeBackground}
-						inSession={inSession}
-						setInSession={setInSession}
-					/>
+					<Timer changeBackground={changeBackground} inSession={inSession} setInSession={setInSession} setReady={setReady} ready={ready} />
 				</Grid>
 				{deepStudy && pinTask !== '' && (
 					<Grid item xs={6} className='pinned-grid'>

--- a/src/pages/styles/Focus.scss
+++ b/src/pages/styles/Focus.scss
@@ -5,8 +5,13 @@
 	min-height: 92vh;
 	padding: 20px;
 	color: #ffffff;
-	background: linear-gradient( #407447 0%, #a0c0ae 74%);
-	
+	background: linear-gradient(#407447 0%, #d3f3e1 74%);
+
+	.end-session {
+		color: #fff;
+		padding: 10px;
+		border: 2px solid #fff;
+	}
 
 	.pinned-grid {
 		margin: 20px;

--- a/src/redux/actions/studyData.js
+++ b/src/redux/actions/studyData.js
@@ -7,14 +7,14 @@ export const studyDataType = {
 };
 
 export const StudyActionCreators = {
-	addLBreak: (time) => ({
+	addLBreak: (times) => ({
 		type: 'ADD_LONG_BREAK',
-		payload: time,
+		payload: { times },
 	}),
-	
-	addSBreak: (time) => ({
+
+	addSBreak: (times) => ({
 		type: 'ADD_SHORT_BREAK',
-		payload: time,
+		payload: { times },
 	}),
 
 	addStudy: (times) => ({

--- a/src/redux/reducers/studyData.js
+++ b/src/redux/reducers/studyData.js
@@ -17,14 +17,14 @@ const studyReducer = (state = initialState, action) => {
 			return {
 				...state,
 				short_breaks_taken: state.short_breaks_taken + 1,
-				short_breaks: [...state.short_breaks, action.payload.time],
+				short_breaks: [...state.short_breaks, action.payload.times],
 			};
-		case Types.ADD_LONG_BREAK:	
-				return {
-					...state,
-					long_breaks_taken: state.long_breaks_taken + 1,
-					long_breaks: [...state.long_breaks, action.payload.time],
-				};
+		case Types.ADD_LONG_BREAK:
+			return {
+				...state,
+				long_breaks_taken: state.long_breaks_taken + 1,
+				long_breaks: [...state.long_breaks, action.payload.times],
+			};
 		case Types.ADD_STUDY:
 			return {
 				...state,


### PR DESCRIPTION
Datapage Graphes init

Session Connected to Graph

Tasks, Breaks and Sessions connected to graph

Pull request checklist:
- [x] Code is clean.
- [ ] Change/Fix is thoroughly tested.
- [x] No additional error produced in the console.
- [x] Only single commit with concise commit message.
- [ ] Proper issue linked
- [x] Proper labels added

Attach issue number (if any): 
fixes <!--issue number>

Description:
Data Tasks, Breaks and Study Data are now displayed in session graphs on the data page.
Scope of change: (components, pages, tools, etc)
Focus: Data Page and Timer Page